### PR TITLE
format stringified JSON in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ githubChangeRemoteFile({
   transform: function (pkg) {
     pkg = JSON.parse(pkg)
     pkg.devDependencies.standard = semver.inc(pkg.devDependencies.standard, 'major')
-    return JSON.stringify(pkg)
+    return JSON.stringify(pkg, null, 2)
   },
   token: '<github access token with sufficent rights>'
 }, function (err, res) {
@@ -35,7 +35,7 @@ githubChangeRemoteFile({
   transform: function (pkg) {
     pkg = JSON.parse(pkg)
     pkg.devDependencies.standard = semver.inc(pkg.devDependencies.standard, 'major')
-    return JSON.stringify(pkg)
+    return JSON.stringify(pkg, null, 2)
   },
   token: '<github access token with sufficent rights>',
   pr: {
@@ -58,7 +58,7 @@ githubChangeRemoteFile({
   transform: function (pkg) {
     pkg = JSON.parse(pkg)
     pkg.devDependencies.standard = semver.inc(pkg.devDependencies.standard, 'major')
-    return JSON.stringify(pkg)
+    return JSON.stringify(pkg, null, 2)
   },
   token: '<github access token with sufficent rights>',
   push: true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Create a new commit:
 githubChangeRemoteFile({
   user: 'boennemann',
   repo: 'animals',
-  filename: 'package.json'
+  filename: 'package.json',
   transform: function (pkg) {
     pkg = JSON.parse(pkg)
     pkg.devDependencies.standard = semver.inc(pkg.devDependencies.standard, 'major')
@@ -31,7 +31,7 @@ Create a new commit and send a PR:
 githubChangeRemoteFile({
   user: 'boennemann',
   repo: 'animals',
-  filename: 'package.json'
+  filename: 'package.json',
   transform: function (pkg) {
     pkg = JSON.parse(pkg)
     pkg.devDependencies.standard = semver.inc(pkg.devDependencies.standard, 'major')


### PR DESCRIPTION
The current README example would generate a commit with flattened JSON. This updates it to beautify the generated JSON string.

For more exact preservation of the formatting, something like https://github.com/substack/jsup could be used.
