### PR TITLE
Only create a commit if contents changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ module.exports = async function (config) {
 
   const content = await contentFromFilename(github, config)
   const newContent = transform(content.content)
+  if (content.content === newContent) throw new Error('No changes to commit')
 
   var transformedConfig = {}
   if (typeof newContent === 'string') transformedConfig.content = newContent

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ const newFileSha = 'cea'
 nock('https://api.github.com')
 .get(`/repos/${user}/${repo}/git/refs/heads%2F${branch}`)
 .query({access_token: accessToken})
-.times(2)
+.times(3)
 .reply(200, {
   object: {
     sha: branchSha
@@ -44,7 +44,7 @@ nock('https://api.github.com')
 
 .get(`/repos/${user}/${repo}/contents/${filename.replace('/', '%2F')}`)
 .query({access_token: accessToken, ref: branch})
-.times(4)
+.times(5)
 .reply(200, {
   content: 'YWJj',
   type: 'file',
@@ -78,6 +78,22 @@ test('create branch and commit', (t) => {
   })
   .then(res => t.is(res.sha, newFileSha))
   .catch(t.threw)
+})
+
+test('not create branch and commit when there are no changes', (t) => {
+  t.plan(1)
+
+  githubChangeRemoteFile({
+    user,
+    repo,
+    filename,
+    branch,
+    newBranch,
+    transform: (input) => input,
+    token: accessToken
+  })
+  .then(res => t.fail())
+  .catch(err => t.pass())
 })
 
 test('push commit to branch', (t) => {


### PR DESCRIPTION
Sometimes transformations result in no changes. `github-change-remote-file` will create an empty commit anyway. Resulting in a pull request that doesn't change anything. I was thinking if we can get around this by comparing the contents before hitting the API.

The PR contains a naive approach to illustrate my thoughts. Basis for discussion 😅 